### PR TITLE
fix_ci

### DIFF
--- a/openshift/release/cron-nightly-ci-run.yaml
+++ b/openshift/release/cron-nightly-ci-run.yaml
@@ -7,6 +7,7 @@ spec:
   successfulJobsHistoryLimit: 1
   concurrencyPolicy: Replace
   schedule: "0 0 * * *"
+  startingDeadlineSeconds: 200
   jobTemplate:
     spec:
       template:

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -5,8 +5,8 @@
 
 set -ex
 REPO_NAME=`basename $(git remote get-url origin)`
-OPENSHIFT_REMOTE=${OPENSHIFT_REMOTE:openshift}
-OPENSHIFT_ORG=${OPENSHIFT_ORG:openshift}
+OPENSHIFT_REMOTE=${OPENSHIFT_REMOTE:-openshift}
+OPENSHIFT_ORG=${OPENSHIFT_ORG:-openshift}
 
 # Reset release-next to upstream/main.
 git fetch upstream main


### PR DESCRIPTION
1. fix setting default values in update-to-head.sh
2. adding startingDeadlineSeconds so that the cron job does not go crazy when did not start on scheduled time