### PR TITLE
openshift: move pipeline sa bounded scc back to anyuid

### DIFF
--- a/pkg/reconciler/openshift/rbac/rbac.go
+++ b/pkg/reconciler/openshift/rbac/rbac.go
@@ -40,7 +40,7 @@ type Reconciler struct {
 var _ nsreconciler.Interface = (*Reconciler)(nil)
 
 const (
-	pipelineRestricted       = "pipeline-restricted"
+	pipelineAnyuid           = "pipeline-anyuid"
 	pipelineSA               = "pipeline"
 	serviceCABundleCofigMap  = "config-service-cabundle"
 	trustedCABundleConfigMap = "config-trusted-cabundle"
@@ -191,17 +191,17 @@ func (r *Reconciler) createRoleBinding(ctx context.Context, sa *corev1.ServiceAc
 func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("finding cluster role pipeline-restricted")
+	logger.Info("finding cluster role pipeline-anyuid")
 
 	clusterRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{Name: pipelineRestricted},
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineAnyuid},
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
 					"security.openshift.io",
 				},
 				ResourceNames: []string{
-					"restricted",
+					"anyuid",
 				},
 				Resources: []string{
 					"securitycontextconstraints",
@@ -214,7 +214,7 @@ func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 	}
 
 	rbacClient := r.kubeClientSet.RbacV1()
-	_, err := rbacClient.ClusterRoles().Get(ctx, pipelineRestricted, metav1.GetOptions{})
+	_, err := rbacClient.ClusterRoles().Get(ctx, pipelineAnyuid, metav1.GetOptions{})
 
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -229,17 +229,17 @@ func (r *Reconciler) ensureSCClusterRole(ctx context.Context) error {
 func (r *Reconciler) ensureSCCRoleBinding(ctx context.Context, sa *corev1.ServiceAccount) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("finding role-binding pipeline-restricted")
+	logger.Info("finding role-binding pipeline-anyuid")
 	rbacClient := r.kubeClientSet.RbacV1()
-	pipelineRB, rbErr := rbacClient.RoleBindings(sa.Namespace).Get(ctx, pipelineRestricted, metav1.GetOptions{})
+	pipelineRB, rbErr := rbacClient.RoleBindings(sa.Namespace).Get(ctx, pipelineAnyuid, metav1.GetOptions{})
 	if rbErr != nil && !errors.IsNotFound(rbErr) {
-		logger.Error(rbErr, "rbac pipeline-restricted get error")
+		logger.Error(rbErr, "rbac pipeline-anyuid get error")
 		return rbErr
 	}
 
-	logger.Info("finding cluster role pipeline-restricted")
-	if _, err := rbacClient.ClusterRoles().Get(ctx, pipelineRestricted, metav1.GetOptions{}); err != nil {
-		logger.Error(err, "finding pipeline-restricted cluster role failed")
+	logger.Info("finding cluster role pipeline-anyuid")
+	if _, err := rbacClient.ClusterRoles().Get(ctx, pipelineAnyuid, metav1.GetOptions{}); err != nil {
+		logger.Error(err, "finding pipeline-anyuid cluster role failed")
 		return err
 	}
 
@@ -254,17 +254,17 @@ func (r *Reconciler) ensureSCCRoleBinding(ctx context.Context, sa *corev1.Servic
 func (r *Reconciler) createSCCRoleBinding(ctx context.Context, sa *corev1.ServiceAccount) error {
 	logger := logging.FromContext(ctx)
 
-	logger.Info("create new rolebinding pipeline-restricted")
+	logger.Info("create new rolebinding pipeline-anyuid")
 	rbacClient := r.kubeClientSet.RbacV1()
 	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: pipelineRestricted, Namespace: sa.Namespace},
-		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: pipelineRestricted},
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineAnyuid, Namespace: sa.Namespace},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: pipelineAnyuid},
 		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: sa.Name, Namespace: sa.Namespace}},
 	}
 
 	_, err := rbacClient.RoleBindings(sa.Namespace).Create(ctx, rb, metav1.CreateOptions{})
 	if err != nil {
-		logger.Error(err, "creation of pipeline-restricted rb failed")
+		logger.Error(err, "creation of pipeline-anyuid rb failed")
 	}
 	return err
 }


### PR DESCRIPTION
Set the scc bound to `pipeline` (default sa) back to `anyuid` from `restricted.

This change is necessary as ClusterTasks shipped with the operator (buildah, s2i...) are
failing with the following error.

```bash
[build : build] level=error msg="Error while applying layer: ApplyLayer exit status 1 stdout: stderr: there might not be enough IDs available in the namespace (requested 0:12 for /var/spool/mail): lchown /var/spool/mail: invalid argument"
[build : build] error creating build container: Error committing the finished image: error adding layer with blob "sha256:a6b97b4963f5ace479dbf5bdc821bdb757de2aef502a39a19b236856827250d0": ApplyLayer exit status 1 stdout: stderr: there might not be enough IDs available in the namespace (requested 0:12 for /var/spool/mail): lchown /var/spool/mail: invalid argument
```

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit c3557d9ac747488732fa55f092106cd395e8d876)