### PR TITLE
[openshift] Add mechamism to cleanup RBAC from TP1.2 builds

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/extension/cleanup-clusterrole-rolebinding.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension/cleanup-clusterrole-rolebinding.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	cleanupClusterRoleName = "pipeline-anyuid"
-	cleanupRoleBindingName = "pipeline-anyuid"
+	cleanupClusterRoleName       = "pipeline-anyuid"
+	cleanupRoleBindingName       = "pipeline-anyuid"
+	cleanupClusterRoleTP12       = "privileged-scc-role"
+	clenupClusterRoleBindingTP12 = "openshift-pipelines-privileged"
 )
 
 func RbacCleanup(ctx context.Context, client kubernetes.Interface) error {
@@ -55,6 +57,11 @@ func RbacCleanup(ctx context.Context, client kubernetes.Interface) error {
 		return err
 	}
 
+	err = cleanUpTP12Rbac(ctx, rbacClient)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -75,5 +82,22 @@ func cleanUpClusterRole(ctx context.Context, rbacClient v1.RbacV1Interface) erro
 			return err
 		}
 	}
+	return nil
+}
+
+func cleanUpTP12Rbac(ctx context.Context, rbacClient v1.RbacV1Interface) error {
+	err := rbacClient.ClusterRoles().Delete(ctx, cleanupClusterRoleTP12, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	err = rbacClient.ClusterRoleBindings().Delete(ctx, clenupClusterRoleBindingTP12, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Add delete k8s api call to delete:

- `ClusterRolebinding: openshift-pipelines-privileged`
- `ClusterRole: privileged-scc-role`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit 73caf3fff4af2c848ac395fc639ba3787403df7a)