### PR TITLE
Using tkn-aac-sa as SA and using nightly-ci-github-hub-token

### DIFF
--- a/openshift/release/cron-nightly-ci-run.yaml
+++ b/openshift/release/cron-nightly-ci-run.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: nightly-pipeline-operator
+          serviceAccountName: tkn-aac-sa
           containers:
           - name: cleanup
             image: quay.io/openshift/origin-cli:4.6

--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -41,8 +41,8 @@ spec:
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: github-token
-                      key: password
+                      name: nightly-ci-github-hub-token
+                      key: hub-token
               image: gcr.io/tekton-releases/dogfooding/hub:latest
               script: |
                 #!/usr/bin/env bash


### PR DESCRIPTION
@chmouel updated the SA and token details so that everything is in sync.