### PR TITLE
Fix tkn task label

### DIFF
--- a/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
+++ b/pkg/reconciler/openshift/tektonaddon/tektonaddon.go
@@ -98,7 +98,6 @@ var _ tektonaddonreconciler.Finalizer = (*Reconciler)(nil)
 var communityResourceURLs = []string{
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.4/jib-maven.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/maven/0.2/maven.yaml",
-	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/tkn/0.2/tkn.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.2/helm-upgrade-from-source.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
 	"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",


### PR DESCRIPTION
Remove tkn from community-tasks (upstream) url list,
as it is overwriting the supoorted tkn task with `provider=community` label

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>