### PR TITLE
Add namespace transformer for ClusterInterceptor

### DIFF
--- a/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-interceptor.yaml
+++ b/pkg/reconciler/common/testdata/test-replace-namespace-in-cluster-interceptor.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: ClusterInterceptor
+metadata:
+  name: cel
+spec:
+  clientConfig:
+    service:
+      name: tekton-triggers-core-interceptors
+      path: "cel"
+      namespace: tekton-pipelines


### PR DESCRIPTION
As of now operator is ignoring namespace transformation
on new Resource [clusterInterceptor] and thus it was giving an error.

Add a `injectNamespaceCRDClusterInterceptorClientConfig` function which
will add transformation for ClusterInterceptor CRD.

Signed-off-by: vinamra28 <vinjain@redhat.com>