### PR TITLE
fix autoprune not exectuing for second resource

### DIFF
--- a/pkg/reconciler/common/prune.go
+++ b/pkg/reconciler/common/prune.go
@@ -142,7 +142,7 @@ func getPruningContainers(resources, namespaces []string, keep int, tknImage str
 			Name:                     jobName,
 			Image:                    tknImage,
 			Command:                  []string{"/bin/sh", "-c"},
-			Args:                     cmdArgs,
+			Args:                     []string{cmdArgs},
 			TerminationMessagePolicy: "FallbackToLogsOnError",
 		}
 		containers = append(containers, container)
@@ -151,11 +151,11 @@ func getPruningContainers(resources, namespaces []string, keep int, tknImage str
 	return containers
 }
 
-func deleteCommand(resources []string, keep int, ns string) []string {
-	cmdArgs := []string{}
+func deleteCommand(resources []string, keep int, ns string) string {
+	var cmdArgs string
 	for _, res := range resources {
-		cmd := "tkn " + strings.ToLower(res) + " delete --keep " + fmt.Sprint(keep) + " -f -n " + ns
-		cmdArgs = append(cmdArgs, cmd)
+		cmd := "tkn " + strings.ToLower(res) + " delete --keep=" + fmt.Sprint(keep) + " -n " + ns + " -f ; "
+		cmdArgs = cmdArgs + cmd
 	}
 	return cmdArgs
 }


### PR DESCRIPTION
earlier resources["pipelinerun", "taskrun"] executes fine
but somehow resources ["taskrun", "pipelinrun"] do not execute
for the second resource.

problem: command created and passed was an array where each
item was treated as an arugement.

Now the commands are single string and seperated by ';'