### PR TITLE
[OpenShift] Optimizes rbac creation and fixes addon e2e test

### DIFF
--- a/pkg/reconciler/common/name_test.go
+++ b/pkg/reconciler/common/name_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package common
 
 import (
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"strings"
 	"testing"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 func TestRestrictLengthWithRandomSuffix(t *testing.T) {

--- a/pkg/reconciler/openshift/tektonconfig/extension.go
+++ b/pkg/reconciler/openshift/tektonconfig/extension.go
@@ -120,9 +120,15 @@ func (oe openshiftExtension) PostReconcile(ctx context.Context, comp v1alpha1.Te
 func (oe openshiftExtension) Finalize(ctx context.Context, comp v1alpha1.TektonComponent) error {
 	configInstance := comp.(*v1alpha1.TektonConfig)
 	if configInstance.Spec.Profile == common.ProfileAll {
-		return extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName)
+		if err := extension.TektonAddonCRDelete(oe.operatorClientSet.OperatorV1alpha1().TektonAddons(), common.AddonResourceName); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	r := rbac{
+		kubeClientSet: oe.kubeClientSet,
+	}
+	return r.cleanUp(ctx)
 }
 
 // configOwnerRef returns owner reference pointing to passed instance

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,6 +32,9 @@ failed=0
 header "Setting up environment"
 install_operator_resources
 
+echo "Wait for TektonConfig creation"
+sleep 30
+
 header "Running Go e2e tests"
 go_test_e2e -timeout=20m ./test/e2e/common ${KUBECONFIG_PARAM} || failed=1
 go_test_e2e -timeout=20m ./test/e2e/${TARGET} ${KUBECONFIG_PARAM} || failed=1

--- a/test/resources/tektonconfigs.go
+++ b/test/resources/tektonconfigs.go
@@ -26,6 +26,7 @@ import (
 
 	mfc "github.com/manifestival/client-go-client"
 	mf "github.com/manifestival/manifestival"
+	"github.com/tektoncd/operator/pkg/reconciler/common"
 
 	"knative.dev/pkg/test/logging"
 
@@ -63,8 +64,21 @@ func EnsureTektonConfigExists(kubeClientSet *kubernetes.Clientset, clients confi
 				Name: names.TektonConfig,
 			},
 			Spec: v1alpha1.TektonConfigSpec{
+				Profile: common.ProfileAll,
 				CommonSpec: v1alpha1.CommonSpec{
 					TargetNamespace: cm.Data["DEFAULT_TARGET_NAMESPACE"],
+				},
+				Addon: v1alpha1.Addon{
+					Params: []v1alpha1.Param{
+						{
+							Name:  "pipelineTemplates",
+							Value: "true",
+						},
+						{
+							Name:  "clusterTasks",
+							Value: "true",
+						},
+					},
 				},
 			},
 		}


### PR DESCRIPTION
This optimizes rbac creation by adding a label to each ns after creating
resources in it. in further reconcilations namespace with the label 
`openshift-pipelines.tekton.dev/namespace-ready: ""` will be ignored for resource creation. 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>