### PR TITLE
[OpenShift] fixes adding label in namespace in rbac creation

### DIFF
--- a/pkg/reconciler/openshift/tektonconfig/rbac.go
+++ b/pkg/reconciler/openshift/tektonconfig/rbac.go
@@ -140,6 +140,9 @@ func (r *rbac) createResources(ctx context.Context) error {
 		// Add `openshift-pipelines.tekton.dev/namespace-ready` label to namespace
 		// so that rbac won't loop on it again
 		nsLabels := n.GetLabels()
+		if len(nsLabels) == 0 {
+			nsLabels = map[string]string{}
+		}
 		nsLabels[namespaceRbacLabel] = "true"
 		n.SetLabels(nsLabels)
 		if _, err := r.kubeClientSet.CoreV1().Namespaces().Update(ctx, &n, metav1.UpdateOptions{}); err != nil {


### PR DESCRIPTION
This fixes the error for nil pointer while adding a label in
namespace. If there are no label then initialize map and then
add label.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>