### PR TITLE
[OpenShift] Fixes rbac for Operator service account

### DIFF
--- a/config/openshift/role.yaml
+++ b/config/openshift/role.yaml
@@ -103,6 +103,8 @@ rules:
   - list
   - update
   - watch
+  - bind
+  - escalate
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Operator's service account cannot create rolebinding from clusterrole
which has roles it doesn't posses for which it requires `bind` verb.
and to create clusteroles it requires `escalate` verb if roles mentioned
in clusterrole are not possesed by it.

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>