### PR TITLE
Improve tektoncd#main to openshift#release-next sync

### DIFF
--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -47,6 +47,9 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -xe
+
+                apk add make
+
                 # Configure git email and name
                 git config user.email "pipelines-dev@redhat.com"
                 git config user.name "OpenShift Pipelines"


### PR DESCRIPTION
Add payload sync: fetch nightly versions of Pipelines and Triggers

Add ClusterTask sync: add call to the ClusterTask sync script

Add operator bundle generation: add a call to bundle generation tool

**Note:** 

- By default the bundle and payload uses `nightly` version(s).
Versioned branches could be configured to use specific versions for
payload and bundle

- Changes needed in gerrit repo will be handled in a parallel patch to gerrit openshift-pipelines repo.
Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>