### PR TITLE
Add --olm-skip-range flag in bundle generation

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -11,6 +11,7 @@ CATALOG_RELEASE_BRANCH=${CATALOG_RELEASE_BRANCH:-release-next}
 # RHOSP (Red Hat OpenShift Pipelines)
 RHOSP_VERSION=${RHOSP_VERSION:-$(date  +"%Y.%-m.%-d")-nightly}
 RHOSP_PREVIOUS_VERSION=${RHOSP_PREVIOUS_VERSION:-$(date  +"%Y.%-m.%-d" --date="yesterday")-nightly}
+OLM_SKIP_RANGE=${OLM_SKIP_RANGE:-\'>=1.5.0 <1.6.0\'}
 LABEL=nightly-ci
 
 function get_buildah_task() {
@@ -54,7 +55,9 @@ BUNDLE_ARGS="--workspace operatorhub/openshift \
              --default-channel stable \
              --fetch-strategy-local \
              --upgrade-strategy-replaces \
-             --operator-release-previous-version ${RHOSP_PREVIOUS_VERSION}"
+             --operator-release-previous-version ${RHOSP_PREVIOUS_VERSION} \
+             --olm-skip-range ${OLM_SKIP_RANGE}"
+
 make operator-bundle
 
 git add openshift OWNERS_ALIASES OWNERS cmd/openshift/operator/kodata operatorhub/openshift


### PR DESCRIPTION
Add `OLM_SKIP_RANGE` variable in `update-to-head.sh` so that the
possiblity is open to set the value of `olm.skipRange` from out side the
script (eg: through configMap when run as cronJob)

Add `--olm-skip-range` to `BUNDLE_ARGS`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>