### PR TITLE
Fix update-to-head script

### DIFF
--- a/openshift/release/nightly-ci-run.yaml
+++ b/openshift/release/nightly-ci-run.yaml
@@ -48,7 +48,8 @@ spec:
                 #!/usr/bin/env bash
                 set -xe
 
-                apk add make
+                # TODO: oct 04, 2021 | NT: separate make steps and hub steps into separate tasks
+                apk add make || true # add this true or remove -x from this script
 
                 # Configure git email and name
                 git config user.email "pipelines-dev@redhat.com"

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -10,7 +10,7 @@ TRIGGERS_VERSION=${TRIGGERS_VERSION:-nightly}
 CATALOG_RELEASE_BRANCH=${CATALOG_RELEASE_BRANCH:-release-next}
 # RHOSP (Red Hat OpenShift Pipelines)
 RHOSP_VERSION=${RHOSP_VERSION:-$(date  +"%Y.%-m.%-d")-nightly}
-RHOSP_PREVIOUS_VERSION=${RHOSP_PREVIOUS_VERSION:-$(date  +"%Y.%-m.%-d" --date="yesterday")-nightly}
+RHOSP_PREVIOUS_VERSION=${RHOSP_PREVIOUS_VERSION:-1.5.2}
 OLM_SKIP_RANGE=${OLM_SKIP_RANGE:-\'>=1.5.0 <1.6.0\'}
 LABEL=nightly-ci
 


### PR DESCRIPTION
Make a hacky fix for non critical error in `apk add make` command

Set default previous version as 1.5.2 to to avoid non platform agnostic
`--d yesterday` in date command

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>